### PR TITLE
Refactor IcaoInformation to use EnumAttribute and update related tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    eccairs (0.1.0)
+    eccairs (1.0.1)
       nokogiri (~> 1.16)
       zeitwerk (~> 2.7)
 
@@ -98,6 +98,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/config/enums/icao_information.yml
+++ b/config/enums/icao_information.yml
@@ -1,6 +1,6 @@
 attribute_id: '28'
 xml_tag: ICAO_Information
-sequence:
+sequence: 0
 values:
   1: Off-shore
   2: United Nations

--- a/lib/eccairs/attributes/icao_information.rb
+++ b/lib/eccairs/attributes/icao_information.rb
@@ -2,10 +2,8 @@
 
 module Eccairs
   module Attributes
-    class IcaoInformation < Eccairs::Base::StringAttribute
-      attribute_id 28
-      xml_tag "ICAO_Information"
-      sequence 0
+    class IcaoInformation < Eccairs::Base::EnumAttribute
+      enums_from :icao_information
     end
   end
 end

--- a/lib/eccairs/entities/aircraft.rb
+++ b/lib/eccairs/entities/aircraft.rb
@@ -440,13 +440,12 @@ module Eccairs
         add_attribute(Eccairs::Attributes::LossOfRevenue, false, value)
       end
 
-      # Add ICAO information (+icao_information+ enum, attribute ID 28 in E5x).
-      # Prefer a taxonomy id from +config/enums/icao_information.yml+ (integer or digits-only string).
-      # @param enum_id [Integer, String] Allowed enum id, or a string +EnumAttribute+ can resolve (e.g. "99").
+      # Add ICAO information
+      # @param value [Object] The attribute value
       # @return [Eccairs::Attributes::IcaoInformation] The created attribute instance
       # @note Attribute ID: 28, XML Tag: ICAO_Information
-      def add_icao_information(enum_id)
-        add_attribute(Eccairs::Attributes::IcaoInformation, false, enum_id)
+      def add_icao_information(value)
+        add_attribute(Eccairs::Attributes::IcaoInformation, false, value)
       end
 
       # Add ssr mode

--- a/lib/eccairs/entities/aircraft.rb
+++ b/lib/eccairs/entities/aircraft.rb
@@ -440,12 +440,13 @@ module Eccairs
         add_attribute(Eccairs::Attributes::LossOfRevenue, false, value)
       end
 
-      # Add icao information
-      # @param value [Object] The attribute value
+      # Add ICAO information (+icao_information+ enum, attribute ID 28 in E5x).
+      # Prefer a taxonomy id from +config/enums/icao_information.yml+ (integer or digits-only string).
+      # @param enum_id [Integer, String] Allowed enum id, or a string +EnumAttribute+ can resolve (e.g. "99").
       # @return [Eccairs::Attributes::IcaoInformation] The created attribute instance
       # @note Attribute ID: 28, XML Tag: ICAO_Information
-      def add_icao_information(value)
-        add_attribute(Eccairs::Attributes::IcaoInformation, false, value)
+      def add_icao_information(enum_id)
+        add_attribute(Eccairs::Attributes::IcaoInformation, false, enum_id)
       end
 
       # Add ssr mode

--- a/lib/eccairs/version.rb
+++ b/lib/eccairs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Eccairs
-  VERSION = "0.1.0"
+  VERSION = "1.0.1"
 end

--- a/spec/eccairs/attributes/icao_information_spec.rb
+++ b/spec/eccairs/attributes/icao_information_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 RSpec.describe Eccairs::Attributes::IcaoInformation do
   describe "class configuration" do
-    it "has correct attribute_id" do
+    it "has correct attribute_id from icao_information.yml" do
       expect(described_class.attribute_id).to eq("28")
     end
 
@@ -12,44 +12,69 @@ RSpec.describe Eccairs::Attributes::IcaoInformation do
       expect(described_class.xml_tag).to eq("ICAO_Information")
     end
 
-    it "inherits from StringAttribute" do
-      expect(described_class.superclass).to eq(Eccairs::Base::StringAttribute)
+    it "inherits from EnumAttribute" do
+      expect(described_class.superclass).to eq(Eccairs::Base::EnumAttribute)
+    end
+
+    it "loads allowed values from icao_information.yml" do
+      expect(described_class.allowed_values).to include(1, 2, 3, 97, 99)
     end
   end
 
   describe "initialization" do
-    it "creates an instance with a value" do
-      instance = described_class.new("ICAO Annex 13 information")
-      expect(instance.value).to eq("ICAO Annex 13 information")
+    it "accepts a valid integer id" do
+      instance = described_class.new(99)
+      expect(instance.value).to eq(99)
+    end
+
+    it "accepts a valid numeric string" do
+      instance = described_class.new("99")
+      expect(instance.value).to eq(99)
+    end
+
+    it "rejects values not in the taxonomy" do
+      expect { described_class.new("not-a-code") }.to raise_error(ArgumentError, /allowed enum value/)
     end
   end
 
   describe "XML generation in occurrence" do
-    it "generates valid XML within an occurrence" do
+    it "generates valid XML when given an integer enum id" do
       set = Eccairs.set
       set.add_occurrence do |occurrence|
         occurrence.add_aircraft do |aircraft|
-          aircraft.add_icao_information("ICAO Annex 13 information")
+          aircraft.add_icao_information(99)
         end
       end
 
       xml = set.to_xml
       expect(xml).to include("ICAO_Information")
       expect(xml).to include('attributeId="28"')
+      expect(xml).to include("99")
+    end
+
+    it "accepts digits-only string enum id (same as other enum add_* callers)" do
+      set = Eccairs.set
+      set.add_occurrence do |occurrence|
+        occurrence.add_aircraft do |aircraft|
+          aircraft.add_icao_information("99")
+        end
+      end
+
+      xml = set.to_xml
+      expect(xml).to include("99")
     end
 
     it "generates XML with correct structure" do
       set = Eccairs.set
       set.add_occurrence do |occurrence|
         occurrence.add_aircraft do |aircraft|
-          aircraft.add_icao_information("ICAO Annex 13 information")
+          aircraft.add_icao_information(Integer(99))
         end
       end
 
       xml = set.to_xml
       expect(xml).to include("<ICAO_Information")
       expect(xml).to include('attributeId="28"')
-      expect(xml).to include(">ICAO Annex 13 information</ICAO_Information>")
     end
   end
 end

--- a/spec/eccairs/attributes/icao_information_spec.rb
+++ b/spec/eccairs/attributes/icao_information_spec.rb
@@ -63,18 +63,5 @@ RSpec.describe Eccairs::Attributes::IcaoInformation do
       xml = set.to_xml
       expect(xml).to include("99")
     end
-
-    it "generates XML with correct structure" do
-      set = Eccairs.set
-      set.add_occurrence do |occurrence|
-        occurrence.add_aircraft do |aircraft|
-          aircraft.add_icao_information(Integer(99))
-        end
-      end
-
-      xml = set.to_xml
-      expect(xml).to include("<ICAO_Information")
-      expect(xml).to include('attributeId="28"')
-    end
   end
 end


### PR DESCRIPTION
resolvers #18 


This pull request updates how the `ICAO_Information` attribute is handled in the codebase, standardizing it as an enum attribute and improving validation and test coverage. The main changes include switching from a free-form string to a controlled taxonomy-based enum, updating the attribute definition, and enhancing related tests.

### Attribute definition and validation updates

* Changed `IcaoInformation` from a `StringAttribute` to an `EnumAttribute`, sourcing allowed values from `config/enums/icao_information.yml` for better data consistency and validation.
* Updated the YAML enum configuration to explicitly set the sequence to `0`, ensuring correct ordering and consistency.

### API and usage improvements

* Modified the `add_icao_information` method in `Eccairs::Entities::Aircraft` to require a valid enum id (integer or digits-only string), matching other enum attribute APIs and enforcing taxonomy use.

### Test enhancements

* Updated and expanded tests for `IcaoInformation` to check inheritance from `EnumAttribute`, allowed values, correct handling of valid/invalid enum ids, and XML generation with enum values.

### Versioning

* Bumped the gem version to `1.0.1` to reflect these breaking and feature changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * ICAO information now uses standardized enumerated values for stronger validation and consistency.
* **Documentation**
  * Minor wording update to reference "ICAO" in the aircraft API text.
* **Tests**
  * Tests updated to validate enum behavior and numeric-id inputs.
* **Chores**
  * Release version bumped to 1.0.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->